### PR TITLE
Change regex to search all groovy files in workspace for go-definition

### DIFF
--- a/src/go-definition-provider.ts
+++ b/src/go-definition-provider.ts
@@ -31,12 +31,12 @@ export class GoDefinitionProvider implements vscode.DefinitionProvider {
       return location;
     } else {
       const fileOrfunction = clickedWords[0];
-      console.log(`Clicked: ${fileOrfunction}.groovy => ${fileOrfunction}`);
+      console.log(`Clicked: ${fileOrfunction}.groovy`);
       // Find files that have the same name of the clicked word
       const functionPosition = findFunctionInDoc(document, fileOrfunction);
       if (functionPosition) {
         return new Promise((resolve, reject) => {
-          resolve( new vscode.Location(document.uri, functionPosition));
+          resolve(new vscode.Location(document.uri, functionPosition));
         });
       }
     }

--- a/src/go-definition-provider.ts
+++ b/src/go-definition-provider.ts
@@ -39,6 +39,13 @@ export class GoDefinitionProvider implements vscode.DefinitionProvider {
           resolve(new vscode.Location(document.uri, functionPosition));
         });
       }
+      // Check if a file has the same name of the clicked word
+      const pattern = `**/${fileOrfunction}.groovy`;
+      return vscode.workspace.findFiles(pattern).then(uris => {
+        return new Promise((resolve, reject) => {
+          resolve(new vscode.Location(uris[0], new vscode.Position(0, 0)));
+        });
+      });
     }
   }
 }

--- a/src/go-definition-provider.ts
+++ b/src/go-definition-provider.ts
@@ -13,7 +13,7 @@ export class GoDefinitionProvider implements vscode.DefinitionProvider {
       const [fileName, functionName] = clickedWords;
       console.log(`Clicked: ${fileName}.groovy => ${functionName}`);
       // Find files that have the same name of the clicked word
-      const pattern = `**/${fileName}.groovy`;
+      const pattern = `**/*.groovy`;
       const location: Thenable<vscode.Location | undefined> = vscode.workspace
         .findFiles(pattern)
         .then(async uris => {

--- a/src/go-definition-provider.ts
+++ b/src/go-definition-provider.ts
@@ -39,7 +39,7 @@ export class GoDefinitionProvider implements vscode.DefinitionProvider {
           resolve(new vscode.Location(document.uri, functionPosition));
         });
       }
-      
+
       // Check if a file has the same name of the clicked word
       const pattern = `**/${fileOrfunction}.groovy`;
       return vscode.workspace.findFiles(pattern).then(uris => {

--- a/src/go-definition-provider.ts
+++ b/src/go-definition-provider.ts
@@ -31,14 +31,15 @@ export class GoDefinitionProvider implements vscode.DefinitionProvider {
       return location;
     } else {
       const fileOrfunction = clickedWords[0];
-      console.log(`Clicked: ${fileOrfunction}.groovy`);
-      // Find files that have the same name of the clicked word
+      console.log(`Clicked: ${fileOrfunction}`);
+      // Check in the current file if a function is declared with this name
       const functionPosition = findFunctionInDoc(document, fileOrfunction);
       if (functionPosition) {
         return new Promise((resolve, reject) => {
           resolve(new vscode.Location(document.uri, functionPosition));
         });
       }
+      
       // Check if a file has the same name of the clicked word
       const pattern = `**/${fileOrfunction}.groovy`;
       return vscode.workspace.findFiles(pattern).then(uris => {

--- a/src/go-definition-provider.ts
+++ b/src/go-definition-provider.ts
@@ -31,22 +31,14 @@ export class GoDefinitionProvider implements vscode.DefinitionProvider {
       return location;
     } else {
       const fileOrfunction = clickedWords[0];
-      console.log(`Clicked: ${fileOrfunction}`);
-      // Check in the current file if a function is declared with this name
+      console.log(`Clicked: ${fileOrfunction}.groovy => ${fileOrfunction}`);
+      // Find files that have the same name of the clicked word
       const functionPosition = findFunctionInDoc(document, fileOrfunction);
       if (functionPosition) {
         return new Promise((resolve, reject) => {
-          resolve(new vscode.Location(document.uri, functionPosition));
+          resolve( new vscode.Location(document.uri, functionPosition));
         });
       }
-
-      // Check if a file has the same name of the clicked word
-      const pattern = `**/${fileOrfunction}.groovy`;
-      return vscode.workspace.findFiles(pattern).then(uris => {
-        return new Promise((resolve, reject) => {
-          resolve(new vscode.Location(uris[0], new vscode.Position(0, 0)));
-        });
-      });
     }
   }
 }
@@ -57,7 +49,7 @@ function findFunctionInDoc(
   functionName: string,
 ): vscode.Position | undefined {
   for (let i = 0; i < document.lineCount; i++) {
-    const functionDeclarationRegex = new RegExp(`\\w+(?: \\w+)? (${functionName}) *\\(.*\\) *{`);
+    const functionDeclarationRegex = new RegExp(`\\w+(?: \\w+)? (${functionName}) *\\(.*`);
     if (document.lineAt(i).text.match(functionDeclarationRegex)) {
       return new vscode.Position(i, 0);
     }


### PR DESCRIPTION
This fix resolves issue #28 that I created. Go-to Definition and Peek Definition search through all .groovy files in the workspace.